### PR TITLE
fix: lowercase repository URLs to match npm provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Then use the element anywhere in your HTML:
 Or skip the install and load it straight from a CDN in an HTML file:
 
 ```html
-<script type="module" src="https://unpkg.com/@rocktimsaikia/github-card@3.0.2"></script>
+<script type="module" src="https://unpkg.com/@rocktimsaikia/github-card@3.0.3"></script>
 ```
 
 ## Attributes

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/RocktimSaikia/github-card.git"
+		"url": "git+https://github.com/rocktimsaikia/github-card.git"
 	},
 	"keywords": [
 		"github",
@@ -34,9 +34,9 @@
 	},
 	"license": "MIT",
 	"bugs": {
-		"url": "https://github.com/RocktimSaikia/github-card/issues"
+		"url": "https://github.com/rocktimsaikia/github-card/issues"
 	},
-	"homepage": "https://github.com/RocktimSaikia/github-card#readme",
+	"homepage": "https://github.com/rocktimsaikia/github-card#readme",
 	"devDependencies": {
 		"@biomejs/biome": "2.4.15",
 		"esbuild": "0.28.0"


### PR DESCRIPTION
Lowercased `repository.url`, `bugs.url`, and `homepage` from `RocktimSaikia` to the canonical `rocktimsaikia` so npm provenance validation passes (it failed the `3.0.3` publish with E422 on a repository-info mismatch), and bumped the README unpkg pin to `3.0.3`.