### PR TITLE
feat: refresh card UI and surface location/company/website meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <div>
 	<h1 align="center">github-card 🌈</h1>
 	<p align="center">Beautiful embeddable GitHub profile card for your portfolio. <br/>
-	Here is a live <a href="https://codepen.io/RocktimSaikia/full/jObbBmR">codepen Demo</a></p>
+	Here is a <a href="https://rocktimsaikia.github.io/github-card/">live demo</a></p>
 	<p align="center">
 		<a href="https://github.com/rocktimsaikia/github-card/actions/workflows/main.yml"><img alt="CI" src="https://github.com/rocktimsaikia/github-card/actions/workflows/main.yml/badge.svg"/></a>
 		<a href="https://www.npmjs.com/package/@rocktimsaikia/github-card"><img src="https://badge.fury.io/js/%40rocktimsaikia%2Fgithub-card.svg" alt="npm version"></a>
 	</p>
-	<p align="center"><a href="https://codepen.io/RocktimSaikia/full/jObbBmR"><img src="https://i.ibb.co/LdZZMdr/github-card.png"/></a></p>
+	<p align="center"><a href="https://rocktimsaikia.github.io/github-card/"><img src="https://i.ibb.co/LdZZMdr/github-card.png"/></a></p>
 </div>
 
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ Or skip the install and load it straight from a CDN in an HTML file:
 <github-card data-user="rocktimsaikia" data-theme="dark"></github-card>
 ```
 
+## Customization
+
+Override the accent color with the `--gh-accent` CSS custom property on the element:
+
+```css
+github-card {
+	--gh-accent: #6366f1;
+}
+```
+
+The card also surfaces `location`, `company`, and `website` from the GitHub profile when present.
+
 ## License
 
 2026 © MIT [Rocktim Saikia](https://rocktimcodes.site)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div>
 	<h1 align="center">github-card 🌈</h1>
 	<p align="center">Beautiful embeddable GitHub profile card for your portfolio. <br/>
-	Here is a <a href="https://rocktimsaikia.github.io/github-card/">live demo</a></p>
+	<a href="https://rocktimsaikia.github.io/github-card/">https://rocktimsaikia.github.io/github-card/</a></p>
 	<p align="center">
 		<a href="https://github.com/rocktimsaikia/github-card/actions/workflows/main.yml"><img alt="CI" src="https://github.com/rocktimsaikia/github-card/actions/workflows/main.yml/badge.svg"/></a>
 		<a href="https://www.npmjs.com/package/@rocktimsaikia/github-card"><img src="https://badge.fury.io/js/%40rocktimsaikia%2Fgithub-card.svg" alt="npm version"></a>

--- a/examples/index.html
+++ b/examples/index.html
@@ -2,52 +2,106 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<title>github-card</title>
+		<title>github-card — demo</title>
 		<style>
 			body {
 				font-family:
 					-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 				margin: 0;
-				padding: 40px 16px;
+				padding: 48px 16px;
+				background: #fafbfc;
+				color: #1f2328;
 			}
-			h2 {
-				margin: 36px 0 8px;
+			h1 {
+				margin: 0 0 4px;
+				text-align: center;
+				font-size: 22px;
+			}
+			.subtitle {
+				margin: 0 0 44px;
 				text-align: center;
 				font-size: 14px;
-				font-weight: 600;
 				color: #57606a;
 			}
-			h2 code {
-				background: #eaeef2;
-				padding: 1px 6px;
-				border-radius: 5px;
-			}
-			.profile {
+			.grid {
 				display: flex;
 				flex-wrap: wrap;
 				justify-content: center;
-				gap: 28px;
+				gap: 44px 32px;
+			}
+			figure {
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				gap: 14px;
+				margin: 0;
+				max-width: 320px;
+			}
+			figcaption {
+				text-align: center;
+			}
+			figcaption strong {
+				display: block;
+				margin-bottom: 8px;
+				font-size: 14px;
+			}
+			figcaption code {
+				display: inline-block;
+				margin: 2px;
+				padding: 3px 8px;
+				border-radius: 6px;
+				background: #eaeef2;
+				font-size: 12px;
+				color: #1f2328;
 			}
 		</style>
 	</head>
 	<body>
-		<h2>Default</h2>
-		<div class="profile">
-			<github-card data-user="rocktimsaikia"></github-card>
-			<github-card data-user="benawad" data-theme="dark"></github-card>
-		</div>
+		<h1>github-card</h1>
+		<p class="subtitle">
+			Each example below shows the exact attributes the card is using.
+		</p>
 
-		<h2>Custom accent — set <code>--gh-accent</code> on the element</h2>
-		<div class="profile">
-			<github-card
-				data-user="sindresorhus"
-				style="--gh-accent: #6366f1"
-			></github-card>
-			<github-card
-				data-user="gaearon"
-				data-theme="dark"
-				style="--gh-accent: #22c55e"
-			></github-card>
+		<div class="grid">
+			<figure>
+				<github-card data-user="rocktimsaikia"></github-card>
+				<figcaption>
+					<strong>Default · light theme</strong>
+					<code>data-user="rocktimsaikia"</code>
+				</figcaption>
+			</figure>
+
+			<figure>
+				<github-card data-user="benawad" data-theme="dark"></github-card>
+				<figcaption>
+					<strong>Dark theme</strong>
+					<code>data-theme="dark"</code>
+				</figcaption>
+			</figure>
+
+			<figure>
+				<github-card
+					data-user="sindresorhus"
+					style="--gh-accent: #6366f1"
+				></github-card>
+				<figcaption>
+					<strong>Custom accent</strong>
+					<code>style="--gh-accent: #6366f1"</code>
+				</figcaption>
+			</figure>
+
+			<figure>
+				<github-card
+					data-user="gaearon"
+					data-theme="dark"
+					style="--gh-accent: #22c55e"
+				></github-card>
+				<figcaption>
+					<strong>Dark + custom accent</strong>
+					<code>data-theme="dark"</code>
+					<code>--gh-accent: #22c55e</code>
+				</figcaption>
+			</figure>
 		</div>
 
 		<script type="module" src="../dist/index.js"></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -2,31 +2,54 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<title>Github-card</title>
-	</head>
-	<style>
-		.profile {
-			display: flex;
-			justify-content: center;
-			margin-top: 50px;
-		}
-		.profile div {
-			margin: 20px;
-		}
-
-		@media screen and (max-width: 992px) {
-			.profile {
-				flex-direction: column;
+		<title>github-card</title>
+		<style>
+			body {
+				font-family:
+					-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+				margin: 0;
+				padding: 40px 16px;
 			}
-		}
-	</style>
+			h2 {
+				margin: 36px 0 8px;
+				text-align: center;
+				font-size: 14px;
+				font-weight: 600;
+				color: #57606a;
+			}
+			h2 code {
+				background: #eaeef2;
+				padding: 1px 6px;
+				border-radius: 5px;
+			}
+			.profile {
+				display: flex;
+				flex-wrap: wrap;
+				justify-content: center;
+				gap: 28px;
+			}
+		</style>
+	</head>
 	<body>
+		<h2>Default</h2>
 		<div class="profile">
-			<github-card data-user="benawad" data-theme="dark"></github-card>
 			<github-card data-user="rocktimsaikia"></github-card>
-			<github-card data-user="sindresorhus" data-theme="dark"></github-card>
+			<github-card data-user="benawad" data-theme="dark"></github-card>
 		</div>
+
+		<h2>Custom accent — set <code>--gh-accent</code> on the element</h2>
+		<div class="profile">
+			<github-card
+				data-user="sindresorhus"
+				style="--gh-accent: #6366f1"
+			></github-card>
+			<github-card
+				data-user="gaearon"
+				data-theme="dark"
+				style="--gh-accent: #22c55e"
+			></github-card>
+		</div>
+
 		<script type="module" src="../dist/index.js"></script>
-		<!-- <script type="module" src="https://unpkg.com/@rocktimsaikia/github-card@latest?module"></script> -->
 	</body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,15 @@
 import escapeHtml from './escape.js';
 import nFormatter from './format.js';
 import widgetStyle from './style.js';
+import safeUrl from './url.js';
+
+// Inline monochrome icons (Material Symbols) for the profile meta row.
+const ICON_LOCATION =
+	'<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5z"/></svg>';
+const ICON_COMPANY =
+	'<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0-4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10zm-2-8h-2v2h2v-2zm0 4h-2v2h2v-2z"/></svg>';
+const ICON_LINK =
+	'<svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>';
 
 const template = document.createElement('template');
 
@@ -60,35 +69,61 @@ class myCard extends HTMLElement {
 		const login = escapeHtml(user.login);
 		const htmlUrl = escapeHtml(user.html_url);
 		const name = escapeHtml(user.name);
-		const bio = escapeHtml(user.bio ?? '');
+		const bioHtml = user.bio
+			? `<p class="card-desc">${escapeHtml(user.bio)}</p>`
+			: '';
+
+		const meta = [];
+		if (user.location) {
+			meta.push(
+				`<span class="meta-item">${ICON_LOCATION}${escapeHtml(user.location)}</span>`,
+			);
+		}
+		if (user.company) {
+			meta.push(
+				`<span class="meta-item">${ICON_COMPANY}${escapeHtml(user.company)}</span>`,
+			);
+		}
+		const blog = safeUrl(user.blog);
+		if (blog) {
+			const label = escapeHtml(String(user.blog).replace(/^https?:\/\//i, ''));
+			meta.push(
+				`<a class="meta-item meta-link" href="${escapeHtml(blog)}" target="_blank" rel="noopener">${ICON_LINK}${label}</a>`,
+			);
+		}
+		const metaHtml = meta.length
+			? `<div class="card-meta">${meta.join('')}</div>`
+			: '';
+
 		return `
-        <div class="cover"></div>
-        <div class="card-wrapper">
-        <a href="https://github.com/${login}" target="_blank" rel="noopener"><img id="github-logo" src="https://i.ibb.co/frv5pB3/github-logo.png" alt="github-logo" border="0"></a>
-        <div class="card-header">
-        <div class="card-img-wrapper"><img src="https://avatars.githubusercontent.com/${login}" alt="${name}"/></div>
-        <h1><a class="card-title" href="${htmlUrl}" target="_blank" rel="noopener">${name}</a></h1>
-        <div class="card-responsename"><a href="${htmlUrl}" target="_blank" rel="noopener">@${login}</a></div>
-        <p class="card-desc">${bio}</p>
-        <div class="card-footer">
-        <div class="footer-box">
-            <div class="box-wrapper">
-                <div class="count">${nFormatter(user.followers)}</div>
-                <div class="box-text">Followers</div>
-            </div>
-            <div class="box-wrapper">
-                <div class="count">${nFormatter(user.following)}</div>
-                <div class="box-text">Following</div>
-            </div>
-            <div class="box-wrapper">
-                <div class="count">${nFormatter(user.public_repos)}</div>
-                <div class="box-text">Repositories</div>
-            </div>
-        </div>
-        </div>
-        </div>
-        </div>
-        `;
+		<div class="cover"></div>
+		<div class="card-wrapper">
+		<a href="https://github.com/${login}" target="_blank" rel="noopener"><img id="github-logo" src="https://i.ibb.co/frv5pB3/github-logo.png" alt="github-logo" border="0"></a>
+		<div class="card-header">
+		<div class="card-img-wrapper"><img src="https://avatars.githubusercontent.com/${login}" alt="${name}"/></div>
+		<h1><a class="card-title" href="${htmlUrl}" target="_blank" rel="noopener">${name}</a></h1>
+		<div class="card-responsename"><a href="${htmlUrl}" target="_blank" rel="noopener">@${login}</a></div>
+		${bioHtml}
+		${metaHtml}
+		<div class="card-footer">
+		<div class="footer-box">
+			<div class="box-wrapper">
+				<div class="count">${nFormatter(user.followers)}</div>
+				<div class="box-text">Followers</div>
+			</div>
+			<div class="box-wrapper">
+				<div class="count">${nFormatter(user.following)}</div>
+				<div class="box-text">Following</div>
+			</div>
+			<div class="box-wrapper">
+				<div class="count">${nFormatter(user.public_repos)}</div>
+				<div class="box-text">Repositories</div>
+			</div>
+		</div>
+		</div>
+		</div>
+		</div>
+		`;
 	}
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,7 @@ class myCard extends HTMLElement {
 			</div>
 			<div class="box-wrapper">
 				<div class="count">${nFormatter(user.public_repos)}</div>
-				<div class="box-text">Repositories</div>
+				<div class="box-text">Repos</div>
 			</div>
 		</div>
 		</div>

--- a/src/style.js
+++ b/src/style.js
@@ -84,6 +84,11 @@ a {
 	background: var(--bg);
 }
 
+h1 {
+	font-size: 21px;
+	line-height: 1.2;
+}
+
 .card-title {
 	display: inline-block;
 	color: var(--title);

--- a/src/style.js
+++ b/src/style.js
@@ -1,133 +1,171 @@
 const widgetStyle = `
-h1, div, p {
-    margin: 0px;
-    padding: 0px;
-    font-family: 'system-ui'
-}
-a{
-    text-decoration: none;
-    color: inherit;
-}
-#github-logo{
-    height: 20px;
-    position: absolute;
-    top: 10px;
-    right: 10px;
-}
-.cover{
-    height: 120px;
-    width: 100%;
-    background: #FF5C5C;
-    position: absolute;
-    left: 0px;
-    top: 0px;
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
+*, *::before, *::after {
+	box-sizing: border-box;
 }
 
 .card {
-    position: relative;
-    display: inline-block;
-    background: #ffffff;
-    border-radius: 5px;
-    box-shadow:  0 12px 13px rgba(0,0,0,0.16), 0 12px 13px rgba(0,0,0,0.16);
-    text-align: center;
-    padding: 20px 50px;
-    margin: 5px;
-    padding-top: 5px;
-    transition: all 0.5s;
+	--accent: var(--gh-accent, #ff5c5c);
+	--bg: #ffffff;
+	--surface: #f6f8fa;
+	--title: #1f2328;
+	--text: #57606a;
+	--muted: #8b949e;
+	--border: rgba(31, 35, 40, 0.1);
+	--shadow: 0 1px 3px rgba(31, 35, 40, 0.08), 0 12px 28px rgba(31, 35, 40, 0.12);
+
+	position: relative;
+	display: inline-block;
+	width: 320px;
+	padding: 0 28px 28px;
+	background: var(--bg);
+	border-radius: 16px;
+	box-shadow: var(--shadow);
+	text-align: center;
+	overflow: hidden;
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+	-webkit-font-smoothing: antialiased;
+	transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
-/* Dark Theme */
-.card.dark{
-    background: #1C1D21;
-}
-.dark .card-title{
-    color: #E4E4E4 !important;
-    font-weight: 500 !important;
-}
-.dark .card-desc{
-    font-weight: 400 !important;
-    color: #c6c6c6 !important;
-} 
-.dark .count{
-    color: #c6c6c6 !important;
-    font-weight: 600 !important;
-} 
-.dark .box-text{
-    color: #797979 !important;
-    font-weight: 500 !important;
-}
-.dark .footer-box{
-    background: #1D2025 !important;
-    box-shadow: 0px 0.2px 5px rgba(255, 255, 255, 0.15), 0px 4px 10px rgba(0, 0, 0, 0.25) !important;
+.card:hover {
+	transform: translateY(-3px);
+	box-shadow: 0 2px 6px rgba(31, 35, 40, 0.1), 0 20px 44px rgba(31, 35, 40, 0.18);
 }
 
+/* Dark theme just remaps the palette variables — no !important overrides. */
+.card.dark {
+	--bg: #16181d;
+	--surface: #1f242c;
+	--title: #e6edf3;
+	--text: #adbac7;
+	--muted: #768390;
+	--border: rgba(255, 255, 255, 0.1);
+	--shadow: 0 1px 3px rgba(0, 0, 0, 0.4), 0 16px 36px rgba(0, 0, 0, 0.55);
+}
 
+a {
+	text-decoration: none;
+	color: inherit;
+}
 
-.card .fa-github {
-    position: absolute;
-    color: #646464;
-    font-size: 20px;
-    top: 10px;
-    right: 10px;
+.cover {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 96px;
+	background: var(--accent);
 }
-.card .card-title {
-    color: #434343;
-    margin-bottom: -8px;
-    font-size: 25px;
-    font-weight: 600;
+
+#github-logo {
+	position: absolute;
+	top: 14px;
+	right: 14px;
+	height: 22px;
+	opacity: 0.85;
+	transition: opacity 0.2s ease;
 }
-.card .card-responsename {
-    margin-bottom: 20px;
-    color: #797979;
+#github-logo:hover {
+	opacity: 1;
 }
-.card .card-desc {
-    font-weight: 500;
-    width: 250px;
-    margin: auto;
-    display: block;
-    color: #3c3c3c;
+
+.card-img-wrapper {
+	position: relative;
+	width: 104px;
+	height: 104px;
+	margin: 44px auto 14px;
 }
-.card .card-img-wrapper {
-    position: relative;
-    height: 160px;
-    width: 160px;
-    margin: 10px auto;
-    margin-bottom: 20px;
+.card-img-wrapper img {
+	width: 100%;
+	height: 100%;
+	border-radius: 50%;
+	object-fit: cover;
+	border: 4px solid var(--bg);
+	background: var(--bg);
 }
-.card .card-img-wrapper img {
-    height: 100%;
-    width: 100%;
-    border-radius: 50%;
+
+.card-title {
+	display: inline-block;
+	color: var(--title);
+	font-size: 21px;
+	font-weight: 700;
+	letter-spacing: -0.01em;
 }
-.card .card-footer {
-    margin-top: 40px;
+
+.card-responsename {
+	margin-top: 2px;
+	color: var(--muted);
+	font-size: 14px;
 }
-.card .card-footer .footer-box {
-    position: relative;
-    border-top: 2px solid #ff9b9b;
-    box-shadow: 0 3px 6px -1px rgb(0 0 0 / 26%), 0 2px 4px -1px rgb(0 0 0 / 6%);
-    border-radius: 5px;
-    margin: 0 auto;
-    padding: 10px;
-    display: flex;
-    justify-content: space-around;
+
+.card-desc {
+	margin: 12px auto 0;
+	max-width: 250px;
+	color: var(--text);
+	font-size: 13.5px;
+	line-height: 1.5;
 }
-.card .card-footer .footer-box .box-wrapper {
-    position: relative;
+
+.card-meta {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	align-items: center;
+	gap: 4px 14px;
+	margin-top: 12px;
 }
-.card .card-footer .footer-box .box-wrapper .count {
-    font-family: 'consolas';
-    color: #434343;
-    font-size: 20px;
-    font-weight: 600;
+.meta-item {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	max-width: 100%;
+	color: var(--muted);
+	font-size: 12.5px;
+	line-height: 1.4;
 }
-.card .card-footer .footer-box .box-wrapper .box-text {
-    font-size: 12px;
-    font-weight: 600;
-    color: #00000085;
-    letter-spacing: 0.5px;
+.meta-item svg {
+	flex-shrink: 0;
+	width: 14px;
+	height: 14px;
+	opacity: 0.8;
+}
+.meta-link {
+	transition: color 0.2s ease;
+}
+.meta-link:hover {
+	color: var(--accent);
+}
+
+.card-footer {
+	margin-top: 20px;
+}
+.footer-box {
+	display: flex;
+	justify-content: space-around;
+	align-items: center;
+	padding: 13px 6px;
+	border: 1px solid var(--border);
+	border-top: 2px solid var(--accent);
+	border-radius: 12px;
+	background: var(--surface);
+}
+.box-wrapper {
+	flex: 1;
+}
+.count {
+	color: var(--title);
+	font-size: 18px;
+	font-weight: 700;
+	font-variant-numeric: tabular-nums;
+	line-height: 1.2;
+}
+.box-text {
+	margin-top: 3px;
+	color: var(--muted);
+	font-size: 10.5px;
+	font-weight: 600;
+	letter-spacing: 0.4px;
+	text-transform: uppercase;
 }
 `;
 

--- a/src/style.js
+++ b/src/style.js
@@ -16,7 +16,7 @@ const widgetStyle = `
 	position: relative;
 	display: inline-block;
 	width: 320px;
-	padding: 0 28px 28px;
+	padding: 0 28px 20px;
 	background: var(--bg);
 	border-radius: 16px;
 	box-shadow: var(--shadow);
@@ -73,7 +73,7 @@ a {
 	position: relative;
 	width: 104px;
 	height: 104px;
-	margin: 44px auto 14px;
+	margin: 44px auto 8px;
 }
 .card-img-wrapper img {
 	width: 100%;

--- a/src/url.js
+++ b/src/url.js
@@ -1,0 +1,12 @@
+// Sanitize a user-supplied URL (e.g. a GitHub profile's `blog` field) before
+// using it in an href: allow only http(s), assume https when no scheme is given,
+// and reject anything else (javascript:, data:, …) to avoid script injection.
+function safeUrl(value) {
+	if (!value) return '';
+	const url = String(value).trim();
+	if (/^https?:\/\//i.test(url)) return url;
+	if (/^[a-z][a-z\d+.-]*:/i.test(url)) return ''; // some other scheme → reject
+	return `https://${url}`;
+}
+
+export default safeUrl;


### PR DESCRIPTION
Refreshed the card UI — unified typography to one system-font stack with tabular-aligned stats, softened shadows, larger radius and consistent spacing, and refactored the dark theme onto CSS custom properties with a public `--gh-accent` override — and added a conditional meta row surfacing the profile's `location`, `company`, and `website` (the website scheme-sanitized via a new `safeUrl` helper to preserve the XSS protection).