### PR TITLE
ci: deploy examples demo to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,60 @@
+name: Deploy demo to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment, cancel in-progress runs.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build bundle
+        run: npm run build
+
+      # Assemble the published site: the demo at /examples/ keeps its relative
+      # `../dist/index.js` reference, and the root redirects to it.
+      - name: Assemble site
+        run: |
+          mkdir -p _site/examples _site/dist
+          cp examples/index.html _site/examples/index.html
+          cp dist/index.js _site/dist/index.js
+          printf '<!doctype html><meta http-equiv="refresh" content="0; url=./examples/">\n' > _site/index.html
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Added a GitHub Actions workflow that builds the bundle and publishes the `examples/` demo to GitHub Pages on every push to master, assembling the demo at `/examples/` (keeping its relative `dist` reference) with a root redirect.